### PR TITLE
Sphinx requires specific version of python-doc-theme

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ pytest-cov
 sphinx<5.0.0
 sphinxcontrib-bibtex
 sphinx-paramlinks
-python-docs-theme
+python-docs-theme<2022.1
 matplotlib
 scipy>=1.6.0
 scikit-learn


### PR DESCRIPTION
cf. https://github.com/python/python-docs-theme/issues/92 and https://github.com/python/python-docs-theme/issues/665