### PR TITLE
Update Boost in Dockerfile_for_pip

### DIFF
--- a/Dockerfile_for_pip
+++ b/Dockerfile_for_pip
@@ -14,9 +14,9 @@ RUN mkdir -p /opt/cmake \
     && rm -f cmake-3.16.2-Linux-x86_64.sh
 
 # yum install boost-devel installs boost 1.53 and copy is the only way to install headers only boost
-RUN curl -LO "https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.gz" \
-    && tar xf boost_1_73_0.tar.gz \
-    && cd boost_1_73_0 \
+RUN curl -LO "https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.gz" \
+    && tar xf boost_1_82_0.tar.gz \
+    && cd boost_1_82_0 \
     && ./bootstrap.sh \
     && ls \
     && cp -r boost /usr/local/include/ \


### PR DESCRIPTION
untested
sadly, I don't see a convenient "latest" link.
For performance reason, it is good if the pip packages are built with the latest boost.