### PR TITLE
gcc version too old for the node version that is mandatory for github actions

### DIFF
--- a/Dockerfile_for_pip
+++ b/Dockerfile_for_pip
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM quay.io/pypa/manylinux_2_28_x86_64
 
 RUN yum -y update && yum -y install \
     curl \
@@ -51,4 +51,4 @@ ENV PYTHON311="/opt/python/cp311-cp311/"
 ENV PYTHON312="/opt/python/cp312-cp312/"
 
 ENV PATH="/opt/cmake/bin:${PATH}"
-ENV PATH="/opt/rh/devtoolset-10/root/usr/bin:${PATH}"
+ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"


### PR DESCRIPTION
cf. https://github.com/GUDHI/gudhi-devel/pull/1161 where pip build is fixed with this new docker image.