### PR TITLE
Nanobind wheels

### DIFF
--- a/Dockerfile_for_pip
+++ b/Dockerfile_for_pip
@@ -14,9 +14,9 @@ RUN mkdir -p /opt/cmake \
     && rm -f cmake-3.16.2-Linux-x86_64.sh
 
 # yum install boost-devel installs boost 1.53 and copy is the only way to install headers only boost
-RUN curl -LO "https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.gz" \
-    && tar xf boost_1_85_0.tar.gz \
-    && cd boost_1_85_0 \
+RUN curl -LO "https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz" \
+    && tar xf boost_1_87_0.tar.gz \
+    && cd boost_1_87_0 \
     && ./bootstrap.sh \
     && ls \
     && cp -r boost /usr/local/include/ \
@@ -28,14 +28,11 @@ RUN chmod +x install_cgal.sh && ./install_cgal.sh
 
 ADD build-requirements.txt /
 
-# gudhi requires numpy >= 1.15.0, but minimal numpy version for python 3.8 is 1.17.3 for instance
-# numpy~=1.17.3 means any numpy=1.17.*, but also numpy>=1.17.3 (numpy~=1.17 do not work as it means any numpy==1.*)
-# For python >=3.9, numpy >= 2.0 for package build and ABI compatibility with numpy 1.X and 2.X
+# gudhi requires numpy >= 1.15.0, but for python >=3.9, numpy >= 2.0 is advised for package build
+# and ABI compatibility with numpy 1.X and 2.X
 # cf. https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
-RUN /opt/python/cp38-cp38/bin/python -m pip install numpy~=1.17.3\
-&& /opt/python/cp38-cp38/bin/python -m pip install twine\
-&& /opt/python/cp38-cp38/bin/python -m pip install -r build-requirements.txt\
-&& /opt/python/cp39-cp39/bin/python -m pip install numpy>=2.0\
+RUN /opt/python/cp39-cp39/bin/python -m pip install numpy>=2.0\
+&& /opt/python/cp39-cp39/bin/python -m pip install twine\
 && /opt/python/cp39-cp39/bin/python -m pip install -r build-requirements.txt\
 && /opt/python/cp310-cp310/bin/python -m pip install numpy>=2.0\
 && /opt/python/cp310-cp310/bin/python -m pip install -r build-requirements.txt\
@@ -46,7 +43,6 @@ RUN /opt/python/cp38-cp38/bin/python -m pip install numpy~=1.17.3\
 && /opt/python/cp313-cp313/bin/python -m pip install numpy>=2.0\
 && /opt/python/cp313-cp313/bin/python -m pip install -r build-requirements.txt
 
-ENV PYTHON38="/opt/python/cp38-cp38/"
 ENV PYTHON39="/opt/python/cp39-cp39/"
 ENV PYTHON310="/opt/python/cp310-cp310/"
 ENV PYTHON311="/opt/python/cp311-cp311/"

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,6 +1,5 @@
-setuptools
 wheel
 numpy>=1.15.0
-Cython>=0.27
-pybind11>=2.6
+nanobind>=1.3.2
+scikit-build-core>=0.4.3
 build

--- a/install_cgal.sh
+++ b/install_cgal.sh
@@ -3,7 +3,7 @@
 # error management : https://dev.to/banks/stop-ignoring-errors-in-bash-3co5
 set -ue
 
-export CGAL_VERSION="5.6.1"
+export CGAL_VERSION="6.0.1"
 
 curl -LO "https://github.com/CGAL/cgal/releases/download/v${CGAL_VERSION}/CGAL-${CGAL_VERSION}.tar.xz"
 tar xf CGAL-${CGAL_VERSION}.tar.xz


### PR DESCRIPTION
* Update CGAL with 6.0.1 last version
* Update build-requirements with nanobind
* Remove python 3.8 support for pip wheel