### PR TITLE
Remove pip install --no-cache-dir

### DIFF
--- a/Dockerfile_for_circleci_image
+++ b/Dockerfile_for_circleci_image
@@ -25,8 +25,8 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN mkdir /home/ubuntu/install
 COPY build-requirements.txt /home/ubuntu/install/
 COPY test-requirements.txt /home/ubuntu/install/
-RUN python -m pip install --no-cache-dir -r /home/ubuntu/install/build-requirements.txt
-RUN python -m pip install --no-cache-dir -r /home/ubuntu/install/test-requirements.txt
+RUN python -m pip install -r /home/ubuntu/install/build-requirements.txt
+RUN python -m pip install -r /home/ubuntu/install/test-requirements.txt
 
 # Try to do the same layers as Dockerfile_for_circle_ci_image_without_cgal
 RUN apt-get install --no-install-recommends -y libeigen3-dev \

--- a/Dockerfile_for_circleci_image_without_cgal
+++ b/Dockerfile_for_circleci_image_without_cgal
@@ -25,8 +25,8 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN mkdir /home/ubuntu/install
 COPY build-requirements.txt /home/ubuntu/install/
 COPY test-requirements.txt /home/ubuntu/install/
-RUN python -m pip install --no-cache-dir -r /home/ubuntu/install/build-requirements.txt
-RUN python -m pip install --no-cache-dir -r /home/ubuntu/install/test-requirements.txt
+RUN python -m pip install -r /home/ubuntu/install/build-requirements.txt
+RUN python -m pip install -r /home/ubuntu/install/test-requirements.txt
 
 # Try to do the same layers as Dockerfile_for_circle_ci_image
 RUN curl -LO "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz" \

--- a/Dockerfile_for_pip
+++ b/Dockerfile_for_pip
@@ -31,17 +31,17 @@ COPY build-requirements.txt /
 # gudhi requires numpy >= 1.15.0, but for python >=3.10, numpy >= 2.0 is advised for package build
 # and ABI compatibility with numpy 1.X and 2.X
 # cf. https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
-RUN /opt/python/cp310-cp310/bin/python -m pip install --no-cache-dir numpy>=2.0\
-&& /opt/python/cp310-cp310/bin/python -m pip install --no-cache-dir twine\
-&& /opt/python/cp310-cp310/bin/python -m pip install --no-cache-dir -r build-requirements.txt\
-&& /opt/python/cp311-cp311/bin/python -m pip install --no-cache-dir numpy>=2.0\
-&& /opt/python/cp311-cp311/bin/python -m pip install --no-cache-dir -r build-requirements.txt\
-&& /opt/python/cp312-cp312/bin/python -m pip install --no-cache-dir numpy>=2.0\
-&& /opt/python/cp312-cp312/bin/python -m pip install --no-cache-dir -r build-requirements.txt\
-&& /opt/python/cp313-cp313/bin/python -m pip install --no-cache-dir numpy>=2.0\
-&& /opt/python/cp313-cp313/bin/python -m pip install --no-cache-dir -r build-requirements.txt\
-&& /opt/python/cp314-cp314/bin/python -m pip install --no-cache-dir numpy>=2.0\
-&& /opt/python/cp314-cp314/bin/python -m pip install --no-cache-dir -r build-requirements.txt
+RUN /opt/python/cp310-cp310/bin/python -m pip install numpy>=2.0\
+&& /opt/python/cp310-cp310/bin/python -m pip install twine\
+&& /opt/python/cp310-cp310/bin/python -m pip install -r build-requirements.txt\
+&& /opt/python/cp311-cp311/bin/python -m pip install numpy>=2.0\
+&& /opt/python/cp311-cp311/bin/python -m pip install -r build-requirements.txt\
+&& /opt/python/cp312-cp312/bin/python -m pip install numpy>=2.0\
+&& /opt/python/cp312-cp312/bin/python -m pip install -r build-requirements.txt\
+&& /opt/python/cp313-cp313/bin/python -m pip install numpy>=2.0\
+&& /opt/python/cp313-cp313/bin/python -m pip install -r build-requirements.txt\
+&& /opt/python/cp314-cp314/bin/python -m pip install numpy>=2.0\
+&& /opt/python/cp314-cp314/bin/python -m pip install -r build-requirements.txt
 
 ENV PYTHON310="/opt/python/cp310-cp310/"
 ENV PYTHON311="/opt/python/cp311-cp311/"


### PR DESCRIPTION
Without the flag, pip uses its local cache and may reuse a previously downloaded wheel. With --no-cache-dir, pip always fetches fresh from PyPI — and PyPI may serve you a different wheel than before.